### PR TITLE
Validate environment for onTopic handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,13 @@ async function initialize(): Promise<void> {
   }
 }
 
+function validateEnvironment(environment: string | null | undefined): boolean {
+  if (!environment && !config.environment) {
+    return true;
+  }
+  return environment === config.environment;
+}
+
 function getParameters(params: SpeechParams): InstantiatedSpeechParams {
   if (params.lang) {
     params.language = params.lang;
@@ -233,12 +240,19 @@ function exceptionHandler(err: Error): void {
 }
 
 if (io.rabbit) {
-  io.rabbit.onTopic('speaker.command.cache.clear', () => {
+  io.rabbit.onTopic('speaker.command.cache.clear', (response) => {
+    const msg = (response.content as { environment?: string });
+    if (!validateEnvironment(msg.environment)) {
+      return;
+    }
     clearCache();
   });
 
   io.rabbit.onTopic('speaker.command.default.language', (response) => {
-    const msg = (response.content as {language: string});
+    const msg = (response.content as { environment?: string; language: string });
+    if (!validateEnvironment(msg.environment)) {
+      return;
+    }
     if (languages[msg.language]) {
       config.language = msg.language;
       logger.info(`Default language set to ${config.language}`);
@@ -249,7 +263,10 @@ if (io.rabbit) {
   });
 
   io.rabbit.onTopic('speaker.command.default.voice', (response) => {
-    const msg = (response.content as {language: string; voice: string});
+    const msg = (response.content as { environment?: string; language: string; voice: string });
+    if (!validateEnvironment(msg.environment)) {
+      return;
+    }
     if (languages[msg.language]) {
       if (languages[msg.language].includes(msg.voice)) {
         config.voices[msg.language] = msg.voice;
@@ -265,7 +282,10 @@ if (io.rabbit) {
   });
 
   io.rabbit.onTopic('speaker.command.volume.change', (response) => {
-    const msg = (response.content as {change?: number; volume?: number});
+    const msg = (response.content as { environment?: string; change?: number; volume?: number });
+    if (!validateEnvironment(msg.environment)) {
+      return;
+    }
     if (msg.change) {
       config.volume = config.volume + msg.change / 100;
     }


### PR DESCRIPTION
PR modifies the `onTopic` listeners so that they will only run if the passed environment matches what's set for `config.environment`. We create `''`, `null`, and `undefined` for the environment as equivalent as the environment variable is not set.